### PR TITLE
Fix device for multi-GPU inference

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -318,6 +318,8 @@ def load_model(
     if debug:
         print(model)
 
+    print(f"Model loaded on {model.device=} for {device=} and {num_gpus=}")
+
     return model, tokenizer
 
 

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -306,7 +306,7 @@ def load_model(
     ):
         model = ipex.optimize(model, dtype=kwargs["torch_dtype"])
 
-    if (device == "cuda" and num_gpus == 1 and not cpu_offloading) or device in (
+    if (device == "cuda" and num_gpus >= 1 and not cpu_offloading) or device in (
         "mps",
         "xpu",
     ):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Fixes a bug where the device was set to CPU when `num_gpus != 1` cc @edbeeching @vwxyzjn you'll need to re-install your fastchat version.

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
