### PR TITLE
Enable loading of chained PEFT models

### DIFF
--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -540,6 +540,11 @@ class PeftModelAdapter:
         base_model, tokenizer = base_adapter.load_model(
             base_model_path, base_model_from_pretrained_kwargs, 
         )
+        # If the base model is also a LoRA adapter, we need to merge those weights **before** loading the second adapter
+        # Without this, you will get garbage outputs!
+        if is_adapter_model(base_model_path, base_model_from_pretrained_kwargs["revision"]) is True:
+            print("Base model is adapter, merging LoRA weights")
+            base_model.merge_and_unload()
         print(f"Base model loaded on device {base_model.device} for {base_model_path=} and {base_model_from_pretrained_kwargs=}")
         model = PeftModel.from_pretrained(base_model, model_path, revision=revision)
         return model, tokenizer

--- a/fastchat/model/model_adapter.py
+++ b/fastchat/model/model_adapter.py
@@ -544,7 +544,8 @@ class PeftModelAdapter:
         # Without this, you will get garbage outputs!
         if is_adapter_model(base_model_path, base_model_from_pretrained_kwargs["revision"]) is True:
             print("Base model is adapter, merging LoRA weights")
-            base_model.merge_and_unload()
+            base_model.eval()
+            base_model = base_model.merge_and_unload()
         print(f"Base model loaded on device {base_model.device} for {base_model_path=} and {base_model_from_pretrained_kwargs=}")
         model = PeftModel.from_pretrained(base_model, model_path, revision=revision)
         return model, tokenizer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 model_worker = ["accelerate>=0.21", "peft", "sentencepiece", "torch", "transformers>=4.31.0"]
 webui = ["gradio"]
 train = ["einops", "flash-attn>=2.0", "wandb"]
-llm_judge = ["openai", "anthropic>=0.3", "ray", "hf_transfer"]
+llm_judge = ["openai", "anthropic>=0.3", "ray"]
 dev = ["black==23.3.0", "pylint==2.8.2"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
 model_worker = ["accelerate>=0.21", "peft", "sentencepiece", "torch", "transformers>=4.31.0"]
 webui = ["gradio"]
 train = ["einops", "flash-attn>=2.0", "wandb"]
-llm_judge = ["openai", "anthropic>=0.3", "ray"]
+llm_judge = ["openai", "anthropic>=0.3", "ray", "hf_transfer"]
 dev = ["black==23.3.0", "pylint==2.8.2"]
 
 [project.urls]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

Needed to enable loading of chained LoRAs, e.g.:

* SFT w LoRA on base model X => LoRA adapter L1 (adapter config points to X)
* DPO on L1 also w LoRA => LoRA adapter L2 (adapter config points to X)

Since `peft` only tracks the root base model X, we need to tell FastChat how to load the SFT adapter first, merge the weights, and then load the DPO adapter on those weights.

The solution is to provide a `base_model_path` arg to `load_model()` which can then track the parent repo with the source adapter.

Related internal Slack thread: https://huggingface.slack.com/archives/C04L3MWLE6B/p1701077078466229

cc @edbeeching 

## Related issue number (if applicable)

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed.
- [ ] I've made sure the relevant tests are passing (if applicable).
